### PR TITLE
Changed is_lan_ip to is_valid_ip

### DIFF
--- a/src/descriptions/en/general.json
+++ b/src/descriptions/en/general.json
@@ -372,7 +372,7 @@
     "is_valid_ip": {
         "description": "Returns `true` in case the provided IP address is valid. Otherwise `false` will get returned.",
         "example": [
-            "print(\"Is valid IP: \" + is_lan_ip(\"1.1.1.1\"))"
+            "print(\"Is valid IP: \" + is_valid_ip(\"1.1.1.1\"))"
         ]
     },
     "bitwise": {


### PR DESCRIPTION
Changed `is_lan_ip` to `is_valid_ip` in the example

[![image](https://github.com/ayecue/greyscript-meta/assets/62176191/8b20d288-3fa4-4d0c-bec4-e7cc39dffd4f)](https://documentation.greyscript.org/?filter=general.is_valid_ip#GENERAL_IS_LAN_IP)